### PR TITLE
Fix GL example

### DIFF
--- a/src/xr/functions.py
+++ b/src/xr/functions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations  # To support python 3.9+ style array type annotations
 # Warning: this file is auto-generated. Do not edit.
 
-from ctypes import POINTER, c_char, c_int64, c_uint32
+from ctypes import POINTER, c_char, c_int64, c_uint32, cast
 
 """
 File xr.functions.py
@@ -16,6 +16,7 @@ from .enums import *
 from .exceptions import check_result
 from .typedefs import *
 
+from .platform import SwapchainImageOpenGLKHR
 
 def get_instance_proc_addr(
     instance: Instance,
@@ -547,6 +548,32 @@ def enumerate_swapchain_images(
         raise result
     return images
 
+def enumerate_swapchain_images_gl(
+    swapchain: Swapchain,
+) -> Array[SwapchainImageOpenGLKHR]:
+    """"""
+    image_capacity_input = c_uint32(0)
+    fxn = raw_functions.xrEnumerateSwapchainImages
+    # First call of two, to retrieve buffer sizes
+    result = check_result(fxn(
+        swapchain,
+        0,
+        byref(image_capacity_input),
+        None,
+    ))
+    if result.is_exception():
+        raise result
+    images = (SwapchainImageOpenGLKHR * image_capacity_input.value)(*([SwapchainImageOpenGLKHR()] * image_capacity_input.value))
+    result = check_result(fxn(
+        swapchain,
+        image_capacity_input,
+        byref(image_capacity_input),
+        cast(images, POINTER(SwapchainImageBaseHeader))
+    ))
+    if result.is_exception():
+        raise result
+    return images
+
 
 def acquire_swapchain_image(
     swapchain: Swapchain,
@@ -1061,6 +1088,7 @@ __all__ = [
     "create_swapchain",
     "destroy_swapchain",
     "enumerate_swapchain_images",
+    "enumerate_swapchain_images_gl",
     "acquire_swapchain_image",
     "wait_swapchain_image",
     "release_swapchain_image",


### PR DESCRIPTION
The generated `enumerate_swapchain_images` function does not work, because OpenXR expects a specific type of swapchain image that corresponds to the rendering API in use.  In this case `SwapchainImageOpenGLKHR` is required.  I've explicitly added that here in order to get a functional result, but the generator logic will have to have some way of dealing with this.  I don't know how you'd pass in the type of array you want back and get that without need for subsequent casting.  

I'm not sure why the `ctor` version of the graphics binding code doesn't work, but this PR changes it to initialize a blank object and then assign to the appropriate variables.  