### PR TITLE
Workaround to prevent gl_example to hang and crash SteamVR

### DIFF
--- a/examples/gl_example.py
+++ b/examples/gl_example.py
@@ -468,7 +468,10 @@ class OpenXrExample(object):
             self.window = None
         self.system_id = None
         if self.instance is not None:
-            xr.destroy_instance(self.instance)
+            # Workaround for https://github.com/ValveSoftware/SteamVR-for-Linux/issues/422
+            # and https://github.com/ValveSoftware/SteamVR-for-Linux/issues/479
+            if platform.system() != 'Linux':
+                xr.destroy_instance(self.instance)
             self.instance = None
         glfw.terminate()
 


### PR DESCRIPTION
On Linux with SteamVR, due to https://github.com/ValveSoftware/SteamVR-for-Linux/issues/422 and https://github.com/ValveSoftware/SteamVR-for-Linux/issues/479, `gl_example.py` hangs when one tries to stop it. If one then tries to kill the app, it either crash SteamVR or prevent any new VR application to start up.

This is a crude workaround that make the application "crashes properly" before hitting the SteamVR bugs

Note: I'm note sure if this should be actually merged in or just kept around as workaround.