### PR TITLE
Fix Varjo quad-view extension

### DIFF
--- a/src/xr/context_object.py
+++ b/src/xr/context_object.py
@@ -264,8 +264,7 @@ class ContextObject(object):
                 )
             )
             num_views = len(views)
-            projection_layer_views = (xr.CompositionLayerProjectionView * num_views)(
-                *([xr.CompositionLayerProjectionView()] * num_views))
+            projection_layer_views = tuple(xr.CompositionLayerProjectionView() for _ in range(num_views))
 
             vsf = view_state.view_state_flags
             if (vsf & xr.VIEW_STATE_POSITION_VALID_BIT == 0


### PR DESCRIPTION
When using XR_VARJO_quad_views extension, there will be 4 views to be rendered, and view_loop will throw an exception because projection_layer_views will only ever contain 2 entries. This commit changes projection_layer_views to follow the array size of views returned from xr.CompositionLayerProjection