### PR TITLE
Fix missing argument for frame_state in ContextObject

### DIFF
--- a/src/xr/context_object.py
+++ b/src/xr/context_object.py
@@ -181,8 +181,9 @@ class ContextObject(object):
                         SessionState.VISIBLE,
                         SessionState.FOCUSED,
                 ):
-                    frame_state = wait_frame(self.session)
-                    begin_frame(self.session)
+                    frame_wait_info = FrameWaitInfo(None)
+                    frame_state = wait_frame(self.session, frame_wait_info)
+                    begin_frame(self.session, None)
                     self.render_layers = []
                     self.graphics.make_current()
 


### PR DESCRIPTION
Hi, 

Some of the examples (color_cube.py, pink_world.py) from https://github.com/cmbruns/pyopenxr_examples/ that used ContextObject were failing for me, with errors such as:

```

    for frame_index, frame_state in enumerate(context.frame_loop()):
                                    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/home/adi/.local/lib/python3.13/site-packages/xr/context_object.py", line 192, in frame_loop
    frame_state = wait_frame(self.session)
TypeError: wait_frame() missing 1 required positional argument: 'frame_wait_info'

    for frame_index, frame_state in enumerate(context.frame_loop()):
                                    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/home/adi/.local/lib/python3.13/site-packages/xr/context_object.py", line 194, in frame_loop
    begin_frame(self.session)
    ~~~~~~~~~~~^^^^^^^^^^^^^^
TypeError: begin_frame() missing 1 required positional argument: 'frame_begin_info'

```

