### PR TITLE
Python 3.14 compatibility (_ctypes)

### DIFF
--- a/src/xr/utils/gl/egl_util.py
+++ b/src/xr/utils/gl/egl_util.py
@@ -1,4 +1,4 @@
-from _ctypes import pointer
+from ctypes import pointer
 from ctypes import cast, c_void_p
 
 from OpenGL import EGL

--- a/src/xr/utils/gl/egl_util.py
+++ b/src/xr/utils/gl/egl_util.py
@@ -1,4 +1,10 @@
-from ctypes import pointer
+import sys
+
+if sys.version_info >= (3, 14):
+    from ctypes import pointer
+else:
+    from _ctypes import pointer
+    
 from ctypes import cast, c_void_p
 
 from OpenGL import EGL


### PR DESCRIPTION
Import pointer from ctypes instead of _ctypes. 

Using Python 3.14 import pointer from _ctypes causes the following exception:

`ImportError: cannot import name 'pointer' from '_ctypes' (C:\Users\paulk\AppData\Local\Programs\Python\Python314\DLLs\_ctypes.pyd)`

Seems that there have been some changes in 3.14. Changing _ctypes to ctypes fixed the issue for me and is working on Python 3.13 and 3.14. Hard to say for me if it has impact on earlier Python versions.

